### PR TITLE
FpsModule hotfix (1.20.1)

### DIFF
--- a/common/src/main/java/me/cominixo/betterf3/mixin/ClientAccessor.java
+++ b/common/src/main/java/me/cominixo/betterf3/mixin/ClientAccessor.java
@@ -1,0 +1,21 @@
+package me.cominixo.betterf3.mixin;
+
+import net.minecraft.client.MinecraftClient;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+/**
+ * FPS count accessor.
+ */
+@Mixin(MinecraftClient.class)
+public interface ClientAccessor {
+  /**
+   * Gets the current client FPS.
+   *
+   * @return the current client FPS
+   */
+  @Accessor("currentFps")
+  static int betterF3$getCurrentFps() {
+    throw new AssertionError();
+  }
+}

--- a/common/src/main/java/me/cominixo/betterf3/modules/FpsModule.java
+++ b/common/src/main/java/me/cominixo/betterf3/modules/FpsModule.java
@@ -1,6 +1,7 @@
 package me.cominixo.betterf3.modules;
 
 import java.util.Collections;
+import me.cominixo.betterf3.mixin.ClientAccessor;
 import me.cominixo.betterf3.utils.DebugLine;
 import me.cominixo.betterf3.utils.Utils;
 import net.minecraft.client.MinecraftClient;
@@ -62,7 +63,7 @@ public class FpsModule extends BaseModule {
    * @param client the Minecraft client
    */
   public void update(final MinecraftClient client) {
-    final int currentFps = Integer.parseInt(client.fpsDebugString.split(" ")[0].split("/")[0].trim());
+    final int currentFps = ClientAccessor.betterF3$getCurrentFps();
 
     final String fpsString = I18n
       .translate("format.betterf3.fps", currentFps,

--- a/common/src/main/resources/betterf3.mixins.json
+++ b/common/src/main/resources/betterf3.mixins.json
@@ -4,6 +4,7 @@
   "compatibilityLevel": "JAVA_17",
   "minVersion": "0.8.4",
   "client": [
+    "ClientAccessor",
     "DebugMixin",
     "KeyboardMixin",
     "autof3.AutomaticDebugMixin",


### PR DESCRIPTION
A faster method of getting the current FPS: Using `MinecraftClient.currentFps` instead of parsing `fpsDebugString`.