### PR TITLE
1.21.7

### DIFF
--- a/docs/changelogs/16.0.0.md
+++ b/docs/changelogs/16.0.0.md
@@ -1,0 +1,4 @@
+! last_version=15.0.0
+!
+### Added
+- 1.21.7 support

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,12 +14,17 @@ maven_group=me.treyruffy.betterf3
 
 platforms=fabric,neoforge
 
+# https://fabricmc.net/develop/
 fabric_loader_version=0.16.14
 fabric_api_version=0.129.0+1.21.7
 
+# https://modrinth.com/mod/cloth-config/versions
 cloth_version=19.0.147
+
+# https://modrinth.com/mod/modmenu/versions
 modmenu_version=15.0.0-beta.3
 
+# https://neoforged.net/
 neoforge_version=21.7.17-beta
 
 modrinth_id=8shC1gFX

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,23 +4,23 @@ org.gradle.daemon=false
 
 archives_base_name=BetterF3
 
-minecraft_version=1.21.6
-supported_minecraft_versions=1.21.6
-supported_minecraft_versions_list=1.21.6
+minecraft_version=1.21.7
+supported_minecraft_versions=1.21.7
+supported_minecraft_versions_list=1.21.7
 
-mod_version=15.0.0
+mod_version=16.0.0
 releaseType=release
 maven_group=me.treyruffy.betterf3
 
 platforms=fabric,neoforge
 
 fabric_loader_version=0.16.14
-fabric_api_version=0.127.1+1.21.6
+fabric_api_version=0.129.0+1.21.7
 
 cloth_version=19.0.147
 modmenu_version=15.0.0-beta.3
 
-neoforge_version=21.6.11-beta
+neoforge_version=21.7.17-beta
 
 modrinth_id=8shC1gFX
 curseforge_id=401648


### PR DESCRIPTION
This PR adds support for Minecraft 1.21.7 (tested with Fabric 1.21.7 only).

It also adds links to referenced resources to improve maintainability.