### PR TITLE
fix(#178): Fix scoreboard hiding logic

### DIFF
--- a/common/src/main/java/me/cominixo/betterf3/mixin/scoreboard/ScoreboardMixin.java
+++ b/common/src/main/java/me/cominixo/betterf3/mixin/scoreboard/ScoreboardMixin.java
@@ -25,7 +25,7 @@ public class ScoreboardMixin {
    */
   @Inject(at = @At("HEAD"), method = "displayScoreboardSidebar", cancellable = true)
   public void init(final CallbackInfo info) {
-    if (!GeneralOptions.disableMod && GeneralOptions.hideSidebar && this.minecraft.getDebugOverlay().showDebugScreen()) {
+    if (!GeneralOptions.disableMod && GeneralOptions.hideSidebar && this.minecraft.debugEntries.isF3Visible()) {
       info.cancel();
     }
   }


### PR DESCRIPTION
Changes the scoreboard hiding logic to be only on F3 open.

Closes #178 