### PR TITLE
feat: Add 26.2 support

### DIFF
--- a/common/src/main/java/me/cominixo/betterf3/config/gui/GeneralOptionsScreen.java
+++ b/common/src/main/java/me/cominixo/betterf3/config/gui/GeneralOptionsScreen.java
@@ -27,7 +27,7 @@ public final class GeneralOptionsScreen {
      * @return the config builder
      */
     public static ConfigBuilder configBuilder(final Minecraft minecraft) {
-        final Screen parent = minecraft.screen;
+        final Screen parent = minecraft.gui.screen();
 
         final ConfigBuilder builder = ConfigBuilder.create()
                 .setParentScreen(parent)

--- a/common/src/main/java/me/cominixo/betterf3/config/gui/ModConfigScreen.java
+++ b/common/src/main/java/me/cominixo/betterf3/config/gui/ModConfigScreen.java
@@ -31,21 +31,21 @@ public class ModConfigScreen extends Screen {
 
         final Button leftButton = Button.builder(
                         Component.translatable("config.betterf3.order_left_button"),
-                        _ -> client.setScreen(new ModulesScreen(this, PositionEnum.LEFT)))
+                        _ -> client.gui.setScreen(new ModulesScreen(this, PositionEnum.LEFT)))
                 .bounds(this.width / 2 - 130, this.height / 4, 120, 20)
                 .build();
         this.addRenderableWidget(leftButton);
 
         final Button rightButton = Button.builder(
                         Component.translatable("config.betterf3.order_right_button"),
-                        _ -> client.setScreen(new ModulesScreen(this, PositionEnum.RIGHT)))
+                        _ -> client.gui.setScreen(new ModulesScreen(this, PositionEnum.RIGHT)))
                 .bounds(this.width / 2 + 10, this.height / 4, 120, 20)
                 .build();
         this.addRenderableWidget(rightButton);
 
         final Button configButton = Button.builder(
                         Component.translatable("config.betterf3.general_settings"),
-                        _ -> client.setScreen(
+                        _ -> client.gui.setScreen(
                                 GeneralOptionsScreen.configBuilder(client).build()))
                 .bounds(this.width / 2 - 130, this.height / 4 - 24, 260, 20)
                 .build();
@@ -53,7 +53,7 @@ public class ModConfigScreen extends Screen {
 
         final Button doneButton = Button.builder(
                         Component.translatable("config.betterf3.modules.done_button"),
-                        _ -> client.setScreen(this.parent))
+                        _ -> client.gui.setScreen(this.parent))
                 .bounds(this.width / 2 - 130, this.height - 50, 260, 20)
                 .build();
         this.addRenderableWidget(doneButton);

--- a/common/src/main/java/me/cominixo/betterf3/config/gui/modules/ModuleListWidget.java
+++ b/common/src/main/java/me/cominixo/betterf3/config/gui/modules/ModuleListWidget.java
@@ -230,7 +230,7 @@ public class ModuleListWidget extends ObjectSelectionList<ModuleListWidget.Modul
 
             context.text(this.client.font, exampleText, x + 43, y + 13, 0xffffffff, true);
 
-            if (this.client.options.touchscreen().get() || hovered) {
+            if (hovered) {
                 context.fill(x, y, x + 32, y + 32, -1601138544);
                 final int v = mouseX - x;
                 final int w = mouseY - y;

--- a/common/src/main/java/me/cominixo/betterf3/config/gui/modules/ModulesScreen.java
+++ b/common/src/main/java/me/cominixo/betterf3/config/gui/modules/ModulesScreen.java
@@ -76,7 +76,7 @@ public final class ModulesScreen extends Screen {
                             final Screen screen = EditModulesScreen.configBuilder(
                                             Objects.requireNonNull(this.modulesListWidget.getSelected()).module, this)
                                     .build();
-                            minecraft.setScreen(screen);
+                            minecraft.gui.setScreen(screen);
                         })
                 .bounds(this.width / 2 - 50, this.height - 50, 100, 20)
                 .build();
@@ -84,7 +84,7 @@ public final class ModulesScreen extends Screen {
 
         final Button addButton = Button.builder(
                         Component.translatable("config.betterf3.modules.add_button"),
-                        _ -> minecraft.setScreen(
+                        _ -> minecraft.gui.setScreen(
                                 AddModuleScreen.configBuilder(this).build()))
                 .bounds(this.width / 2 + 4 + 50, this.height - 50, 100, 20)
                 .build();
@@ -103,7 +103,7 @@ public final class ModulesScreen extends Screen {
 
         final Button doneButton = Button.builder(Component.translatable("config.betterf3.modules.done_button"), _ -> {
                     this.onClose();
-                    minecraft.setScreen(this.parent);
+                    minecraft.gui.setScreen(this.parent);
                 })
                 .bounds(this.width / 2 - 154, this.height - 30 + 4, 308, 20)
                 .build();
@@ -133,7 +133,7 @@ public final class ModulesScreen extends Screen {
                 BaseModule.modulesRight.add(entry.module);
             }
         }
-        this.minecraft.setScreen(this.parent);
+        this.minecraft.gui.setScreen(this.parent);
         ModConfigFile.saveRunnable.run();
     }
 

--- a/common/src/main/java/me/cominixo/betterf3/mixin/KeyboardMixin.java
+++ b/common/src/main/java/me/cominixo/betterf3/mixin/KeyboardMixin.java
@@ -36,7 +36,7 @@ public abstract class KeyboardMixin {
     public void processF3(final KeyEvent event, final CallbackInfoReturnable<Boolean> cir) {
         final int key = event.key();
         if (key == 77) { // Key m
-            this.minecraft.setScreen(new ModConfigScreen(null));
+            this.minecraft.gui.setScreen(new ModConfigScreen(null));
             cir.setReturnValue(true);
         } else if (key == 70) {
             if (event.hasControlDown()) {

--- a/common/src/main/java/me/cominixo/betterf3/mixin/autof3/DebugOptionMixin.java
+++ b/common/src/main/java/me/cominixo/betterf3/mixin/autof3/DebugOptionMixin.java
@@ -65,7 +65,7 @@ public abstract class DebugOptionMixin {
         if (!GeneralOptions.disableMod
                 && GeneralOptions.autoF3
                 && this.minecraft.debugEntries.isOverlayVisible()
-                && !this.minecraft.options.hideGui) {
+                && !this.minecraft.gui.hud.isHidden()) {
             cir.setReturnValue(this.minecraft.level != null);
         }
     }

--- a/common/src/main/java/me/cominixo/betterf3/modules/ChunksModule.java
+++ b/common/src/main/java/me/cominixo/betterf3/modules/ChunksModule.java
@@ -117,11 +117,11 @@ public class ChunksModule extends BaseModule {
         if (client.levelRenderer.viewArea == null) {
             totalChunks = 0;
         } else {
-            totalChunks = client.levelRenderer.viewArea.sections.length;
+            totalChunks = client.levelRenderer.viewArea.sections.size();
         }
-        final int renderedChunks = client.levelRenderer.countRenderedSections();
+        final int renderedChunks = client.levelExtractor.countRenderedSections();
 
-        final SectionRenderDispatcher chunkBuilder = client.levelRenderer.getSectionRenderDispatcher();
+        final SectionRenderDispatcher chunkBuilder = client.levelRenderer.sectionRenderDispatcher();
 
         if (client.level == null) {
             return;

--- a/common/src/main/java/me/cominixo/betterf3/modules/EntityModule.java
+++ b/common/src/main/java/me/cominixo/betterf3/modules/EntityModule.java
@@ -63,7 +63,7 @@ public class EntityModule extends BaseModule {
      */
     public void update(final Minecraft client) {
 
-        if (client.levelRenderer.level == null) {
+        if (client.level == null) {
             return;
         }
 
@@ -72,12 +72,12 @@ public class EntityModule extends BaseModule {
                 Utils.styledText(I18n.get("text.betterf3.line.total"), this.totalColor),
                 Utils.styledText(
                         client.gameRenderer
-                                .getGameRenderState()
+                                .gameRenderState()
                                 .levelRenderState
                                 .entityRenderStates
                                 .size(),
                         valueColor),
-                Utils.styledText(client.levelRenderer.level.getEntityCount(), this.totalColor));
+                Utils.styledText(client.level.getEntityCount(), this.totalColor));
 
         final IntegratedServer integratedServer = client.getSingleplayerServer();
 

--- a/common/src/main/java/me/cominixo/betterf3/modules/GraphicsModule.java
+++ b/common/src/main/java/me/cominixo/betterf3/modules/GraphicsModule.java
@@ -44,7 +44,7 @@ public class GraphicsModule extends BaseModule {
                         : I18n.get("text" + ".betterf3.line.fancy"));
 
         // Render Distance
-        lines.get(0).value(client.levelRenderer.lastViewDistance);
+        lines.get(0).value(client.levelExtractor.lastViewDistance);
         // Graphics
         lines.get(1)
                 .value(StringUtils.capitalize(

--- a/common/src/main/java/me/cominixo/betterf3/modules/MinecraftModule.java
+++ b/common/src/main/java/me/cominixo/betterf3/modules/MinecraftModule.java
@@ -35,10 +35,6 @@ public class MinecraftModule extends BaseModule {
         lines.getFirst()
                 .value(SharedConstants.getCurrentVersion().name() + " (" + client.getLaunchedVersion() + "/"
                         + ClientBrandRetriever.getClientModName()
-                        + ("release".equalsIgnoreCase(client.getVersionType())
-                                        || client.options.reducedDebugInfo().get()
-                                ? ""
-                                : "/" + client.getVersionType())
                         + ")");
     }
 

--- a/common/src/main/java/me/cominixo/betterf3/modules/SystemModule.java
+++ b/common/src/main/java/me/cominixo/betterf3/modules/SystemModule.java
@@ -63,7 +63,7 @@ public class SystemModule extends BaseModule {
         lines.add(new DebugLine("display"));
         lines.add(new DebugLine("gpu"));
         lines.add(new DebugLine("gpu_utilization"));
-        lines.add(new DebugLine("opengl_version"));
+        lines.add(new DebugLine("graphics_api"));
         lines.add(new DebugLine("gpu_driver"));
 
         for (final DebugLine line : lines) {
@@ -102,11 +102,12 @@ public class SystemModule extends BaseModule {
         final String allocationRateStr = String.format("% 2d MB/s", this.allocationRate(usedMemory) / 1024 / 1024);
         final String allocatedMemory =
                 String.format("% 2d%% %03dMB", totalMemory * 100 / maxMemory, totalMemory / 1024 / 1024);
-        final String displayInfo =
-                String.format("%d x %d (%s)", window.getWidth(), window.getHeight(), gpuDevice.getVendor());
+        final String displayInfo = String.format(
+                "%d x %d (%s)",
+                window.getWidth(), window.getHeight(), gpuDevice.getDeviceInfo().vendorName());
 
-        final String openGlVersion = gpuDevice.getBackendName();
-        final String gpuDriverVersion = gpuDevice.getVersion();
+        final String graphicsApi = gpuDevice.getDeviceInfo().backendName();
+        final String gpuDriverVersion = gpuDevice.getDeviceInfo().driverInfo();
         final String gpuUtilization = gpuUtilization();
 
         lines.get(0).value(time);
@@ -120,9 +121,9 @@ public class SystemModule extends BaseModule {
         lines.get(4).value(allocatedMemory);
         lines.get(5).value(GLX._getCpuInfo());
         lines.get(6).value(displayInfo);
-        lines.get(7).value(gpuDevice.getRenderer());
+        lines.get(7).value(gpuDevice.getDeviceInfo().name());
         lines.get(8).value(gpuUtilization);
-        lines.get(9).value(openGlVersion);
+        lines.get(9).value(graphicsApi);
         lines.get(10).value(gpuDriverVersion);
     }
 

--- a/common/src/main/java/me/cominixo/betterf3/utils/DebugRenderer.java
+++ b/common/src/main/java/me/cominixo/betterf3/utils/DebugRenderer.java
@@ -203,8 +203,9 @@ public final class DebugRenderer {
         final List<Component> list = new ArrayList<>(Math.max(16, modules.size() * 6));
 
         if (minecraft.level == null
-                || (minecraft.screen != null
-                        && !(minecraft.screen instanceof ModulesScreen || minecraft.screen instanceof ChatScreen))) {
+                || (minecraft.gui.screen() != null
+                        && !(minecraft.gui.screen() instanceof ModulesScreen
+                                || minecraft.gui.screen() instanceof ChatScreen))) {
             return list;
         }
 

--- a/common/src/main/resources/assets/betterf3/lang/af_za.json
+++ b/common/src/main/resources/assets/betterf3/lang/af_za.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.opengl_version": "OpenGL Version",
+  "text.betterf3.line.graphics_api": "Graphics API",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/af_za.json
+++ b/common/src/main/resources/assets/betterf3/lang/af_za.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.graphics_api": "Graphics API",
+  "text.betterf3.line.opengl_version": "OpenGL Version",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/ar_sa.json
+++ b/common/src/main/resources/assets/betterf3/lang/ar_sa.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.opengl_version": "OpenGL Version",
+  "text.betterf3.line.graphics_api": "Graphics API",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/ar_sa.json
+++ b/common/src/main/resources/assets/betterf3/lang/ar_sa.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.graphics_api": "Graphics API",
+  "text.betterf3.line.opengl_version": "OpenGL Version",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/ast_es.json
+++ b/common/src/main/resources/assets/betterf3/lang/ast_es.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.opengl_version": "OpenGL Version",
+  "text.betterf3.line.graphics_api": "Graphics API",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/ast_es.json
+++ b/common/src/main/resources/assets/betterf3/lang/ast_es.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.graphics_api": "Graphics API",
+  "text.betterf3.line.opengl_version": "OpenGL Version",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/az_az.json
+++ b/common/src/main/resources/assets/betterf3/lang/az_az.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.opengl_version": "OpenGL Version",
+  "text.betterf3.line.graphics_api": "Graphics API",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/az_az.json
+++ b/common/src/main/resources/assets/betterf3/lang/az_az.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.graphics_api": "Graphics API",
+  "text.betterf3.line.opengl_version": "OpenGL Version",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/ba_ru.json
+++ b/common/src/main/resources/assets/betterf3/lang/ba_ru.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.opengl_version": "OpenGL Version",
+  "text.betterf3.line.graphics_api": "Graphics API",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/ba_ru.json
+++ b/common/src/main/resources/assets/betterf3/lang/ba_ru.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.graphics_api": "Graphics API",
+  "text.betterf3.line.opengl_version": "OpenGL Version",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/be_by.json
+++ b/common/src/main/resources/assets/betterf3/lang/be_by.json
@@ -213,6 +213,7 @@
   "text.betterf3.line.display": "Дысплэй",
   "text.betterf3.line.gpu": "Графічны працэсар",
   "text.betterf3.line.gpu_utilization": "Утылізацыя GPU",
+  "text.betterf3.line.opengl_version": "Версія OpenGL",
   "text.betterf3.line.gpu_driver": "Драйвер GPU",
   "text.betterf3.line.misc_left": "\"Рознае\" злева",
   "text.betterf3.line.misc_right": "\"Рознае\" справа",

--- a/common/src/main/resources/assets/betterf3/lang/be_by.json
+++ b/common/src/main/resources/assets/betterf3/lang/be_by.json
@@ -213,7 +213,6 @@
   "text.betterf3.line.display": "Дысплэй",
   "text.betterf3.line.gpu": "Графічны працэсар",
   "text.betterf3.line.gpu_utilization": "Утылізацыя GPU",
-  "text.betterf3.line.opengl_version": "Версія OpenGL",
   "text.betterf3.line.gpu_driver": "Драйвер GPU",
   "text.betterf3.line.misc_left": "\"Рознае\" злева",
   "text.betterf3.line.misc_right": "\"Рознае\" справа",

--- a/common/src/main/resources/assets/betterf3/lang/bg.json
+++ b/common/src/main/resources/assets/betterf3/lang/bg.json
@@ -213,7 +213,6 @@
   "text.betterf3.line.display": "Екран",
   "text.betterf3.line.gpu": "Видеокарта",
   "text.betterf3.line.gpu_utilization": "Използване на GPU",
-  "text.betterf3.line.opengl_version": "Версия на OpenGL",
   "text.betterf3.line.gpu_driver": "GPU драйвер",
   "text.betterf3.line.misc_left": "Misc ляво",
   "text.betterf3.line.misc_right": "Misc дясно",

--- a/common/src/main/resources/assets/betterf3/lang/bg.json
+++ b/common/src/main/resources/assets/betterf3/lang/bg.json
@@ -213,6 +213,7 @@
   "text.betterf3.line.display": "Екран",
   "text.betterf3.line.gpu": "Видеокарта",
   "text.betterf3.line.gpu_utilization": "Използване на GPU",
+  "text.betterf3.line.opengl_version": "Версия на OpenGL",
   "text.betterf3.line.gpu_driver": "GPU драйвер",
   "text.betterf3.line.misc_left": "Misc ляво",
   "text.betterf3.line.misc_right": "Misc дясно",

--- a/common/src/main/resources/assets/betterf3/lang/bn.json
+++ b/common/src/main/resources/assets/betterf3/lang/bn.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.opengl_version": "OpenGL Version",
+  "text.betterf3.line.graphics_api": "Graphics API",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/bn.json
+++ b/common/src/main/resources/assets/betterf3/lang/bn.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.graphics_api": "Graphics API",
+  "text.betterf3.line.opengl_version": "OpenGL Version",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/br.json
+++ b/common/src/main/resources/assets/betterf3/lang/br.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.opengl_version": "OpenGL Version",
+  "text.betterf3.line.graphics_api": "Graphics API",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/br.json
+++ b/common/src/main/resources/assets/betterf3/lang/br.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.graphics_api": "Graphics API",
+  "text.betterf3.line.opengl_version": "OpenGL Version",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/bs.json
+++ b/common/src/main/resources/assets/betterf3/lang/bs.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.opengl_version": "OpenGL Version",
+  "text.betterf3.line.graphics_api": "Graphics API",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/bs.json
+++ b/common/src/main/resources/assets/betterf3/lang/bs.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.graphics_api": "Graphics API",
+  "text.betterf3.line.opengl_version": "OpenGL Version",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/ca_es.json
+++ b/common/src/main/resources/assets/betterf3/lang/ca_es.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.opengl_version": "OpenGL Version",
+  "text.betterf3.line.graphics_api": "Graphics API",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/ca_es.json
+++ b/common/src/main/resources/assets/betterf3/lang/ca_es.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.graphics_api": "Graphics API",
+  "text.betterf3.line.opengl_version": "OpenGL Version",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/cs_cz.json
+++ b/common/src/main/resources/assets/betterf3/lang/cs_cz.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.opengl_version": "OpenGL Version",
+  "text.betterf3.line.graphics_api": "Graphics API",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/cs_cz.json
+++ b/common/src/main/resources/assets/betterf3/lang/cs_cz.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.graphics_api": "Graphics API",
+  "text.betterf3.line.opengl_version": "OpenGL Version",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/cy_gb.json
+++ b/common/src/main/resources/assets/betterf3/lang/cy_gb.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.opengl_version": "OpenGL Version",
+  "text.betterf3.line.graphics_api": "Graphics API",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/cy_gb.json
+++ b/common/src/main/resources/assets/betterf3/lang/cy_gb.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.graphics_api": "Graphics API",
+  "text.betterf3.line.opengl_version": "OpenGL Version",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/da_dk.json
+++ b/common/src/main/resources/assets/betterf3/lang/da_dk.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.opengl_version": "OpenGL Version",
+  "text.betterf3.line.graphics_api": "Graphics API",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/da_dk.json
+++ b/common/src/main/resources/assets/betterf3/lang/da_dk.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.graphics_api": "Graphics API",
+  "text.betterf3.line.opengl_version": "OpenGL Version",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/de_at.json
+++ b/common/src/main/resources/assets/betterf3/lang/de_at.json
@@ -213,6 +213,7 @@
   "text.betterf3.line.display": "Anzeige",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Auslastung",
+  "text.betterf3.line.opengl_version": "OpenGL-Version",
   "text.betterf3.line.gpu_driver": "GPU-Treiber",
   "text.betterf3.line.misc_left": "Sonstiges Links",
   "text.betterf3.line.misc_right": "Sonstiges Rechts",

--- a/common/src/main/resources/assets/betterf3/lang/de_at.json
+++ b/common/src/main/resources/assets/betterf3/lang/de_at.json
@@ -213,7 +213,6 @@
   "text.betterf3.line.display": "Anzeige",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Auslastung",
-  "text.betterf3.line.opengl_version": "OpenGL-Version",
   "text.betterf3.line.gpu_driver": "GPU-Treiber",
   "text.betterf3.line.misc_left": "Sonstiges Links",
   "text.betterf3.line.misc_right": "Sonstiges Rechts",

--- a/common/src/main/resources/assets/betterf3/lang/de_ch.json
+++ b/common/src/main/resources/assets/betterf3/lang/de_ch.json
@@ -213,6 +213,7 @@
   "text.betterf3.line.display": "Anzeige",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Auslastung",
+  "text.betterf3.line.opengl_version": "OpenGL-Version",
   "text.betterf3.line.gpu_driver": "GPU-Treiber",
   "text.betterf3.line.misc_left": "Sonstiges Links",
   "text.betterf3.line.misc_right": "Sonstiges Rechts",

--- a/common/src/main/resources/assets/betterf3/lang/de_ch.json
+++ b/common/src/main/resources/assets/betterf3/lang/de_ch.json
@@ -213,7 +213,6 @@
   "text.betterf3.line.display": "Anzeige",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Auslastung",
-  "text.betterf3.line.opengl_version": "OpenGL-Version",
   "text.betterf3.line.gpu_driver": "GPU-Treiber",
   "text.betterf3.line.misc_left": "Sonstiges Links",
   "text.betterf3.line.misc_right": "Sonstiges Rechts",

--- a/common/src/main/resources/assets/betterf3/lang/de_de.json
+++ b/common/src/main/resources/assets/betterf3/lang/de_de.json
@@ -213,6 +213,7 @@
   "text.betterf3.line.display": "Anzeige",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Auslastung",
+  "text.betterf3.line.opengl_version": "OpenGL-Version",
   "text.betterf3.line.gpu_driver": "GPU-Treiber",
   "text.betterf3.line.misc_left": "Sonstiges Links",
   "text.betterf3.line.misc_right": "Sonstiges Rechts",

--- a/common/src/main/resources/assets/betterf3/lang/de_de.json
+++ b/common/src/main/resources/assets/betterf3/lang/de_de.json
@@ -213,7 +213,6 @@
   "text.betterf3.line.display": "Anzeige",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Auslastung",
-  "text.betterf3.line.opengl_version": "OpenGL-Version",
   "text.betterf3.line.gpu_driver": "GPU-Treiber",
   "text.betterf3.line.misc_left": "Sonstiges Links",
   "text.betterf3.line.misc_right": "Sonstiges Rechts",

--- a/common/src/main/resources/assets/betterf3/lang/el_gr.json
+++ b/common/src/main/resources/assets/betterf3/lang/el_gr.json
@@ -213,7 +213,6 @@
   "text.betterf3.line.display": "Οθόνη",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.opengl_version": "Έκδοση OpenGL",
   "text.betterf3.line.gpu_driver": "Πρόγραμμα Οδήγησης GPU",
   "text.betterf3.line.misc_left": "Διάφορα Αριστερά",
   "text.betterf3.line.misc_right": "Διάφορα Δεξιά",

--- a/common/src/main/resources/assets/betterf3/lang/el_gr.json
+++ b/common/src/main/resources/assets/betterf3/lang/el_gr.json
@@ -213,6 +213,7 @@
   "text.betterf3.line.display": "Οθόνη",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
+  "text.betterf3.line.opengl_version": "Έκδοση OpenGL",
   "text.betterf3.line.gpu_driver": "Πρόγραμμα Οδήγησης GPU",
   "text.betterf3.line.misc_left": "Διάφορα Αριστερά",
   "text.betterf3.line.misc_right": "Διάφορα Δεξιά",

--- a/common/src/main/resources/assets/betterf3/lang/en_au.json
+++ b/common/src/main/resources/assets/betterf3/lang/en_au.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.opengl_version": "OpenGL Version",
+  "text.betterf3.line.graphics_api": "Graphics API",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/en_au.json
+++ b/common/src/main/resources/assets/betterf3/lang/en_au.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.graphics_api": "Graphics API",
+  "text.betterf3.line.opengl_version": "OpenGL Version",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/en_ca.json
+++ b/common/src/main/resources/assets/betterf3/lang/en_ca.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.opengl_version": "OpenGL Version",
+  "text.betterf3.line.graphics_api": "Graphics API",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/en_ca.json
+++ b/common/src/main/resources/assets/betterf3/lang/en_ca.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.graphics_api": "Graphics API",
+  "text.betterf3.line.opengl_version": "OpenGL Version",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/en_gb.json
+++ b/common/src/main/resources/assets/betterf3/lang/en_gb.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.opengl_version": "OpenGL Version",
+  "text.betterf3.line.graphics_api": "Graphics API",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/en_gb.json
+++ b/common/src/main/resources/assets/betterf3/lang/en_gb.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.graphics_api": "Graphics API",
+  "text.betterf3.line.opengl_version": "OpenGL Version",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/en_nz.json
+++ b/common/src/main/resources/assets/betterf3/lang/en_nz.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.opengl_version": "OpenGL Version",
+  "text.betterf3.line.graphics_api": "Graphics API",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/en_nz.json
+++ b/common/src/main/resources/assets/betterf3/lang/en_nz.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.graphics_api": "Graphics API",
+  "text.betterf3.line.opengl_version": "OpenGL Version",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/en_pt.json
+++ b/common/src/main/resources/assets/betterf3/lang/en_pt.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.opengl_version": "OpenGL Version",
+  "text.betterf3.line.graphics_api": "Graphics API",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/en_pt.json
+++ b/common/src/main/resources/assets/betterf3/lang/en_pt.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.graphics_api": "Graphics API",
+  "text.betterf3.line.opengl_version": "OpenGL Version",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/en_ud.json
+++ b/common/src/main/resources/assets/betterf3/lang/en_ud.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "ʎɐꞁdsᴉᗡ",
   "text.betterf3.line.gpu": "∩Ԁ⅁",
   "text.betterf3.line.gpu_utilization": "uoᴉʇɐsꞁᴉʇ∩ ∩Ԁ⅁",
-  "text.betterf3.line.opengl_version": "uoᴉsɹǝɅ Ꞁ⅁uǝdO",
+  "text.betterf3.line.graphics_api": "uoᴉsɹǝɅ Ꞁ⅁uǝdO",
   "text.betterf3.line.gpu_driver": "ɹǝʌᴉɹᗡ ∩Ԁ⅁",
   "text.betterf3.line.misc_left": "ʇɟǝꞀ ɔsᴉW",
   "text.betterf3.line.misc_right": "ʇɥᵷᴉᴚ ɔsᴉW",

--- a/common/src/main/resources/assets/betterf3/lang/en_ud.json
+++ b/common/src/main/resources/assets/betterf3/lang/en_ud.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "ʎɐꞁdsᴉᗡ",
   "text.betterf3.line.gpu": "∩Ԁ⅁",
   "text.betterf3.line.gpu_utilization": "uoᴉʇɐsꞁᴉʇ∩ ∩Ԁ⅁",
-  "text.betterf3.line.graphics_api": "uoᴉsɹǝɅ Ꞁ⅁uǝdO",
+  "text.betterf3.line.opengl_version": "uoᴉsɹǝɅ Ꞁ⅁uǝdO",
   "text.betterf3.line.gpu_driver": "ɹǝʌᴉɹᗡ ∩Ԁ⅁",
   "text.betterf3.line.misc_left": "ʇɟǝꞀ ɔsᴉW",
   "text.betterf3.line.misc_right": "ʇɥᵷᴉᴚ ɔsᴉW",

--- a/common/src/main/resources/assets/betterf3/lang/en_us.json
+++ b/common/src/main/resources/assets/betterf3/lang/en_us.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.opengl_version": "OpenGL Version",
+  "text.betterf3.line.graphics_api": "Graphics API",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/en_us.json
+++ b/common/src/main/resources/assets/betterf3/lang/en_us.json
@@ -213,6 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
+  "text.betterf3.line.opengl_version": "OpenGL Version",
   "text.betterf3.line.graphics_api": "Graphics API",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",

--- a/common/src/main/resources/assets/betterf3/lang/eo_uy.json
+++ b/common/src/main/resources/assets/betterf3/lang/eo_uy.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.opengl_version": "OpenGL Version",
+  "text.betterf3.line.graphics_api": "Graphics API",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/eo_uy.json
+++ b/common/src/main/resources/assets/betterf3/lang/eo_uy.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.graphics_api": "Graphics API",
+  "text.betterf3.line.opengl_version": "OpenGL Version",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/es_ar.json
+++ b/common/src/main/resources/assets/betterf3/lang/es_ar.json
@@ -213,6 +213,7 @@
   "text.betterf3.line.display": "Pantalla",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "Utilización de GPU",
+  "text.betterf3.line.opengl_version": "Versión de OpenGL",
   "text.betterf3.line.gpu_driver": "Driver de GPU",
   "text.betterf3.line.misc_left": "Misceláneo Izquierdo",
   "text.betterf3.line.misc_right": "Misceláneo Derecho",

--- a/common/src/main/resources/assets/betterf3/lang/es_ar.json
+++ b/common/src/main/resources/assets/betterf3/lang/es_ar.json
@@ -213,7 +213,6 @@
   "text.betterf3.line.display": "Pantalla",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "Utilización de GPU",
-  "text.betterf3.line.opengl_version": "Versión de OpenGL",
   "text.betterf3.line.gpu_driver": "Driver de GPU",
   "text.betterf3.line.misc_left": "Misceláneo Izquierdo",
   "text.betterf3.line.misc_right": "Misceláneo Derecho",

--- a/common/src/main/resources/assets/betterf3/lang/es_cl.json
+++ b/common/src/main/resources/assets/betterf3/lang/es_cl.json
@@ -213,6 +213,7 @@
   "text.betterf3.line.display": "Pantalla",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "Utilización de GPU",
+  "text.betterf3.line.opengl_version": "Versión de OpenGL",
   "text.betterf3.line.gpu_driver": "Driver de GPU",
   "text.betterf3.line.misc_left": "Misceláneo Izquierdo",
   "text.betterf3.line.misc_right": "Misceláneo Derecho",

--- a/common/src/main/resources/assets/betterf3/lang/es_cl.json
+++ b/common/src/main/resources/assets/betterf3/lang/es_cl.json
@@ -213,7 +213,6 @@
   "text.betterf3.line.display": "Pantalla",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "Utilización de GPU",
-  "text.betterf3.line.opengl_version": "Versión de OpenGL",
   "text.betterf3.line.gpu_driver": "Driver de GPU",
   "text.betterf3.line.misc_left": "Misceláneo Izquierdo",
   "text.betterf3.line.misc_right": "Misceláneo Derecho",

--- a/common/src/main/resources/assets/betterf3/lang/es_ec.json
+++ b/common/src/main/resources/assets/betterf3/lang/es_ec.json
@@ -213,6 +213,7 @@
   "text.betterf3.line.display": "Pantalla",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "Utilización de GPU",
+  "text.betterf3.line.opengl_version": "Versión de OpenGL",
   "text.betterf3.line.gpu_driver": "Driver de GPU",
   "text.betterf3.line.misc_left": "Misceláneo Izquierdo",
   "text.betterf3.line.misc_right": "Misceláneo Derecho",

--- a/common/src/main/resources/assets/betterf3/lang/es_ec.json
+++ b/common/src/main/resources/assets/betterf3/lang/es_ec.json
@@ -213,7 +213,6 @@
   "text.betterf3.line.display": "Pantalla",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "Utilización de GPU",
-  "text.betterf3.line.opengl_version": "Versión de OpenGL",
   "text.betterf3.line.gpu_driver": "Driver de GPU",
   "text.betterf3.line.misc_left": "Misceláneo Izquierdo",
   "text.betterf3.line.misc_right": "Misceláneo Derecho",

--- a/common/src/main/resources/assets/betterf3/lang/es_es.json
+++ b/common/src/main/resources/assets/betterf3/lang/es_es.json
@@ -213,6 +213,7 @@
   "text.betterf3.line.display": "Pantalla",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "Utilización de GPU",
+  "text.betterf3.line.opengl_version": "Versión de OpenGL",
   "text.betterf3.line.gpu_driver": "Driver de GPU",
   "text.betterf3.line.misc_left": "Misceláneo Izquierdo",
   "text.betterf3.line.misc_right": "Misceláneo Derecho",

--- a/common/src/main/resources/assets/betterf3/lang/es_es.json
+++ b/common/src/main/resources/assets/betterf3/lang/es_es.json
@@ -213,7 +213,6 @@
   "text.betterf3.line.display": "Pantalla",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "Utilización de GPU",
-  "text.betterf3.line.opengl_version": "Versión de OpenGL",
   "text.betterf3.line.gpu_driver": "Driver de GPU",
   "text.betterf3.line.misc_left": "Misceláneo Izquierdo",
   "text.betterf3.line.misc_right": "Misceláneo Derecho",

--- a/common/src/main/resources/assets/betterf3/lang/es_mx.json
+++ b/common/src/main/resources/assets/betterf3/lang/es_mx.json
@@ -213,6 +213,7 @@
   "text.betterf3.line.display": "Pantalla",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "Utilización de GPU",
+  "text.betterf3.line.opengl_version": "Versión de OpenGL",
   "text.betterf3.line.gpu_driver": "Driver de GPU",
   "text.betterf3.line.misc_left": "Misceláneo Izquierdo",
   "text.betterf3.line.misc_right": "Misceláneo Derecho",

--- a/common/src/main/resources/assets/betterf3/lang/es_mx.json
+++ b/common/src/main/resources/assets/betterf3/lang/es_mx.json
@@ -213,7 +213,6 @@
   "text.betterf3.line.display": "Pantalla",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "Utilización de GPU",
-  "text.betterf3.line.opengl_version": "Versión de OpenGL",
   "text.betterf3.line.gpu_driver": "Driver de GPU",
   "text.betterf3.line.misc_left": "Misceláneo Izquierdo",
   "text.betterf3.line.misc_right": "Misceláneo Derecho",

--- a/common/src/main/resources/assets/betterf3/lang/es_uy.json
+++ b/common/src/main/resources/assets/betterf3/lang/es_uy.json
@@ -213,6 +213,7 @@
   "text.betterf3.line.display": "Pantalla",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "Utilización de GPU",
+  "text.betterf3.line.opengl_version": "Versión de OpenGL",
   "text.betterf3.line.gpu_driver": "Driver de GPU",
   "text.betterf3.line.misc_left": "Misceláneo Izquierdo",
   "text.betterf3.line.misc_right": "Misceláneo Derecho",

--- a/common/src/main/resources/assets/betterf3/lang/es_uy.json
+++ b/common/src/main/resources/assets/betterf3/lang/es_uy.json
@@ -213,7 +213,6 @@
   "text.betterf3.line.display": "Pantalla",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "Utilización de GPU",
-  "text.betterf3.line.opengl_version": "Versión de OpenGL",
   "text.betterf3.line.gpu_driver": "Driver de GPU",
   "text.betterf3.line.misc_left": "Misceláneo Izquierdo",
   "text.betterf3.line.misc_right": "Misceláneo Derecho",

--- a/common/src/main/resources/assets/betterf3/lang/es_ve.json
+++ b/common/src/main/resources/assets/betterf3/lang/es_ve.json
@@ -213,6 +213,7 @@
   "text.betterf3.line.display": "Pantalla",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "Utilización de GPU",
+  "text.betterf3.line.opengl_version": "Versión de OpenGL",
   "text.betterf3.line.gpu_driver": "Driver de GPU",
   "text.betterf3.line.misc_left": "Misceláneo Izquierdo",
   "text.betterf3.line.misc_right": "Misceláneo Derecho",

--- a/common/src/main/resources/assets/betterf3/lang/es_ve.json
+++ b/common/src/main/resources/assets/betterf3/lang/es_ve.json
@@ -213,7 +213,6 @@
   "text.betterf3.line.display": "Pantalla",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "Utilización de GPU",
-  "text.betterf3.line.opengl_version": "Versión de OpenGL",
   "text.betterf3.line.gpu_driver": "Driver de GPU",
   "text.betterf3.line.misc_left": "Misceláneo Izquierdo",
   "text.betterf3.line.misc_right": "Misceláneo Derecho",

--- a/common/src/main/resources/assets/betterf3/lang/et_ee.json
+++ b/common/src/main/resources/assets/betterf3/lang/et_ee.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.opengl_version": "OpenGL Version",
+  "text.betterf3.line.graphics_api": "Graphics API",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/et_ee.json
+++ b/common/src/main/resources/assets/betterf3/lang/et_ee.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.graphics_api": "Graphics API",
+  "text.betterf3.line.opengl_version": "OpenGL Version",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/eu_es.json
+++ b/common/src/main/resources/assets/betterf3/lang/eu_es.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.opengl_version": "OpenGL Version",
+  "text.betterf3.line.graphics_api": "Graphics API",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/eu_es.json
+++ b/common/src/main/resources/assets/betterf3/lang/eu_es.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.graphics_api": "Graphics API",
+  "text.betterf3.line.opengl_version": "OpenGL Version",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/fa_ir.json
+++ b/common/src/main/resources/assets/betterf3/lang/fa_ir.json
@@ -213,7 +213,6 @@
   "text.betterf3.line.display": "نمایش",
   "text.betterf3.line.gpu": "پردازنده‌ی گرافیکی",
   "text.betterf3.line.gpu_utilization": "کارایی پردازنده‌ی گرافیکی",
-  "text.betterf3.line.opengl_version": "نسخه‌ی OpenGL",
   "text.betterf3.line.gpu_driver": "درایور پردازنده‌ی گرافیکی",
   "text.betterf3.line.misc_left": "متفرقه سمت چپ",
   "text.betterf3.line.misc_right": "متفرقه سمت راست",

--- a/common/src/main/resources/assets/betterf3/lang/fa_ir.json
+++ b/common/src/main/resources/assets/betterf3/lang/fa_ir.json
@@ -213,6 +213,7 @@
   "text.betterf3.line.display": "نمایش",
   "text.betterf3.line.gpu": "پردازنده‌ی گرافیکی",
   "text.betterf3.line.gpu_utilization": "کارایی پردازنده‌ی گرافیکی",
+  "text.betterf3.line.opengl_version": "نسخه‌ی OpenGL",
   "text.betterf3.line.gpu_driver": "درایور پردازنده‌ی گرافیکی",
   "text.betterf3.line.misc_left": "متفرقه سمت چپ",
   "text.betterf3.line.misc_right": "متفرقه سمت راست",

--- a/common/src/main/resources/assets/betterf3/lang/fi_fi.json
+++ b/common/src/main/resources/assets/betterf3/lang/fi_fi.json
@@ -213,6 +213,7 @@
   "text.betterf3.line.display": "Näyttö",
   "text.betterf3.line.gpu": "Näytönohjain",
   "text.betterf3.line.gpu_utilization": "GPU:n käyttö",
+  "text.betterf3.line.opengl_version": "OpenGL Versio",
   "text.betterf3.line.gpu_driver": "GPU Ajuri",
   "text.betterf3.line.misc_left": "Muut Vasemmat",
   "text.betterf3.line.misc_right": "Muut Oikeat",

--- a/common/src/main/resources/assets/betterf3/lang/fi_fi.json
+++ b/common/src/main/resources/assets/betterf3/lang/fi_fi.json
@@ -213,7 +213,6 @@
   "text.betterf3.line.display": "Näyttö",
   "text.betterf3.line.gpu": "Näytönohjain",
   "text.betterf3.line.gpu_utilization": "GPU:n käyttö",
-  "text.betterf3.line.opengl_version": "OpenGL Versio",
   "text.betterf3.line.gpu_driver": "GPU Ajuri",
   "text.betterf3.line.misc_left": "Muut Vasemmat",
   "text.betterf3.line.misc_right": "Muut Oikeat",

--- a/common/src/main/resources/assets/betterf3/lang/fil_ph.json
+++ b/common/src/main/resources/assets/betterf3/lang/fil_ph.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.opengl_version": "OpenGL Version",
+  "text.betterf3.line.graphics_api": "Graphics API",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/fil_ph.json
+++ b/common/src/main/resources/assets/betterf3/lang/fil_ph.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.graphics_api": "Graphics API",
+  "text.betterf3.line.opengl_version": "OpenGL Version",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/fo_fo.json
+++ b/common/src/main/resources/assets/betterf3/lang/fo_fo.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.opengl_version": "OpenGL Version",
+  "text.betterf3.line.graphics_api": "Graphics API",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/fo_fo.json
+++ b/common/src/main/resources/assets/betterf3/lang/fo_fo.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.graphics_api": "Graphics API",
+  "text.betterf3.line.opengl_version": "OpenGL Version",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/fr_ca.json
+++ b/common/src/main/resources/assets/betterf3/lang/fr_ca.json
@@ -213,6 +213,7 @@
   "text.betterf3.line.display": "Affichage",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "Utilisation du GPU",
+  "text.betterf3.line.opengl_version": "Version OpenGL",
   "text.betterf3.line.gpu_driver": "Pilote GPU",
   "text.betterf3.line.misc_left": "Divers à gauche",
   "text.betterf3.line.misc_right": "Divers à droite",

--- a/common/src/main/resources/assets/betterf3/lang/fr_ca.json
+++ b/common/src/main/resources/assets/betterf3/lang/fr_ca.json
@@ -213,7 +213,6 @@
   "text.betterf3.line.display": "Affichage",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "Utilisation du GPU",
-  "text.betterf3.line.opengl_version": "Version OpenGL",
   "text.betterf3.line.gpu_driver": "Pilote GPU",
   "text.betterf3.line.misc_left": "Divers à gauche",
   "text.betterf3.line.misc_right": "Divers à droite",

--- a/common/src/main/resources/assets/betterf3/lang/fr_fr.json
+++ b/common/src/main/resources/assets/betterf3/lang/fr_fr.json
@@ -213,6 +213,7 @@
   "text.betterf3.line.display": "Affichage",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "Utilisation du GPU",
+  "text.betterf3.line.opengl_version": "Version OpenGL",
   "text.betterf3.line.gpu_driver": "Pilote GPU",
   "text.betterf3.line.misc_left": "Divers à gauche",
   "text.betterf3.line.misc_right": "Divers à droite",

--- a/common/src/main/resources/assets/betterf3/lang/fr_fr.json
+++ b/common/src/main/resources/assets/betterf3/lang/fr_fr.json
@@ -213,7 +213,6 @@
   "text.betterf3.line.display": "Affichage",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "Utilisation du GPU",
-  "text.betterf3.line.opengl_version": "Version OpenGL",
   "text.betterf3.line.gpu_driver": "Pilote GPU",
   "text.betterf3.line.misc_left": "Divers à gauche",
   "text.betterf3.line.misc_right": "Divers à droite",

--- a/common/src/main/resources/assets/betterf3/lang/fra_de.json
+++ b/common/src/main/resources/assets/betterf3/lang/fra_de.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.opengl_version": "OpenGL Version",
+  "text.betterf3.line.graphics_api": "Graphics API",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/fra_de.json
+++ b/common/src/main/resources/assets/betterf3/lang/fra_de.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.graphics_api": "Graphics API",
+  "text.betterf3.line.opengl_version": "OpenGL Version",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/fur.json
+++ b/common/src/main/resources/assets/betterf3/lang/fur.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.opengl_version": "OpenGL Version",
+  "text.betterf3.line.graphics_api": "Graphics API",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/fur.json
+++ b/common/src/main/resources/assets/betterf3/lang/fur.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.graphics_api": "Graphics API",
+  "text.betterf3.line.opengl_version": "OpenGL Version",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/fy_nl.json
+++ b/common/src/main/resources/assets/betterf3/lang/fy_nl.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.opengl_version": "OpenGL Version",
+  "text.betterf3.line.graphics_api": "Graphics API",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/fy_nl.json
+++ b/common/src/main/resources/assets/betterf3/lang/fy_nl.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.graphics_api": "Graphics API",
+  "text.betterf3.line.opengl_version": "OpenGL Version",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/ga_ie.json
+++ b/common/src/main/resources/assets/betterf3/lang/ga_ie.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.opengl_version": "OpenGL Version",
+  "text.betterf3.line.graphics_api": "Graphics API",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/ga_ie.json
+++ b/common/src/main/resources/assets/betterf3/lang/ga_ie.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.graphics_api": "Graphics API",
+  "text.betterf3.line.opengl_version": "OpenGL Version",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/gd_gb.json
+++ b/common/src/main/resources/assets/betterf3/lang/gd_gb.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.opengl_version": "OpenGL Version",
+  "text.betterf3.line.graphics_api": "Graphics API",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/gd_gb.json
+++ b/common/src/main/resources/assets/betterf3/lang/gd_gb.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.graphics_api": "Graphics API",
+  "text.betterf3.line.opengl_version": "OpenGL Version",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/gl_es.json
+++ b/common/src/main/resources/assets/betterf3/lang/gl_es.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.opengl_version": "OpenGL Version",
+  "text.betterf3.line.graphics_api": "Graphics API",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/gl_es.json
+++ b/common/src/main/resources/assets/betterf3/lang/gl_es.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.graphics_api": "Graphics API",
+  "text.betterf3.line.opengl_version": "OpenGL Version",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/haw_us.json
+++ b/common/src/main/resources/assets/betterf3/lang/haw_us.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.opengl_version": "OpenGL Version",
+  "text.betterf3.line.graphics_api": "Graphics API",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/haw_us.json
+++ b/common/src/main/resources/assets/betterf3/lang/haw_us.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.graphics_api": "Graphics API",
+  "text.betterf3.line.opengl_version": "OpenGL Version",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/he_il.json
+++ b/common/src/main/resources/assets/betterf3/lang/he_il.json
@@ -213,7 +213,6 @@
   "text.betterf3.line.display": "הצג",
   "text.betterf3.line.gpu": "מעבד גרפי",
   "text.betterf3.line.gpu_utilization": "ניצול מעבד גרפי",
-  "text.betterf3.line.opengl_version": "גירסת OpenGL",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "שונות שמאל",
   "text.betterf3.line.misc_right": "שונות ימין",

--- a/common/src/main/resources/assets/betterf3/lang/he_il.json
+++ b/common/src/main/resources/assets/betterf3/lang/he_il.json
@@ -213,6 +213,7 @@
   "text.betterf3.line.display": "הצג",
   "text.betterf3.line.gpu": "מעבד גרפי",
   "text.betterf3.line.gpu_utilization": "ניצול מעבד גרפי",
+  "text.betterf3.line.opengl_version": "גירסת OpenGL",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "שונות שמאל",
   "text.betterf3.line.misc_right": "שונות ימין",

--- a/common/src/main/resources/assets/betterf3/lang/hi_in.json
+++ b/common/src/main/resources/assets/betterf3/lang/hi_in.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.opengl_version": "OpenGL Version",
+  "text.betterf3.line.graphics_api": "Graphics API",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/hi_in.json
+++ b/common/src/main/resources/assets/betterf3/lang/hi_in.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.graphics_api": "Graphics API",
+  "text.betterf3.line.opengl_version": "OpenGL Version",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/hu_hu.json
+++ b/common/src/main/resources/assets/betterf3/lang/hu_hu.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.opengl_version": "OpenGL Version",
+  "text.betterf3.line.graphics_api": "Graphics API",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/hu_hu.json
+++ b/common/src/main/resources/assets/betterf3/lang/hu_hu.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.graphics_api": "Graphics API",
+  "text.betterf3.line.opengl_version": "OpenGL Version",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/hy_am.json
+++ b/common/src/main/resources/assets/betterf3/lang/hy_am.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.opengl_version": "OpenGL Version",
+  "text.betterf3.line.graphics_api": "Graphics API",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/hy_am.json
+++ b/common/src/main/resources/assets/betterf3/lang/hy_am.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.graphics_api": "Graphics API",
+  "text.betterf3.line.opengl_version": "OpenGL Version",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/id_id.json
+++ b/common/src/main/resources/assets/betterf3/lang/id_id.json
@@ -213,7 +213,6 @@
   "text.betterf3.line.display": "Layar",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "Pemanfaatan GPU",
-  "text.betterf3.line.opengl_version": "Versi OpenGL",
   "text.betterf3.line.gpu_driver": "Driver GPU",
   "text.betterf3.line.misc_left": "Lain-lain Kiri",
   "text.betterf3.line.misc_right": "Lain-lain Kanan",

--- a/common/src/main/resources/assets/betterf3/lang/id_id.json
+++ b/common/src/main/resources/assets/betterf3/lang/id_id.json
@@ -213,6 +213,7 @@
   "text.betterf3.line.display": "Layar",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "Pemanfaatan GPU",
+  "text.betterf3.line.opengl_version": "Versi OpenGL",
   "text.betterf3.line.gpu_driver": "Driver GPU",
   "text.betterf3.line.misc_left": "Lain-lain Kiri",
   "text.betterf3.line.misc_right": "Lain-lain Kanan",

--- a/common/src/main/resources/assets/betterf3/lang/ig_ng.json
+++ b/common/src/main/resources/assets/betterf3/lang/ig_ng.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.opengl_version": "OpenGL Version",
+  "text.betterf3.line.graphics_api": "Graphics API",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/ig_ng.json
+++ b/common/src/main/resources/assets/betterf3/lang/ig_ng.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.graphics_api": "Graphics API",
+  "text.betterf3.line.opengl_version": "OpenGL Version",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/io_en.json
+++ b/common/src/main/resources/assets/betterf3/lang/io_en.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.opengl_version": "OpenGL Version",
+  "text.betterf3.line.graphics_api": "Graphics API",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/io_en.json
+++ b/common/src/main/resources/assets/betterf3/lang/io_en.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.graphics_api": "Graphics API",
+  "text.betterf3.line.opengl_version": "OpenGL Version",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/is_is.json
+++ b/common/src/main/resources/assets/betterf3/lang/is_is.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.opengl_version": "OpenGL Version",
+  "text.betterf3.line.graphics_api": "Graphics API",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/is_is.json
+++ b/common/src/main/resources/assets/betterf3/lang/is_is.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.graphics_api": "Graphics API",
+  "text.betterf3.line.opengl_version": "OpenGL Version",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/it_it.json
+++ b/common/src/main/resources/assets/betterf3/lang/it_it.json
@@ -213,6 +213,7 @@
   "text.betterf3.line.display": "Schermo",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "Utilizzo della GPU",
+  "text.betterf3.line.opengl_version": "Versione di OpenGL",
   "text.betterf3.line.gpu_driver": "Driver della GPU",
   "text.betterf3.line.misc_left": "Varie sinistra",
   "text.betterf3.line.misc_right": "Varie destra",

--- a/common/src/main/resources/assets/betterf3/lang/it_it.json
+++ b/common/src/main/resources/assets/betterf3/lang/it_it.json
@@ -213,7 +213,6 @@
   "text.betterf3.line.display": "Schermo",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "Utilizzo della GPU",
-  "text.betterf3.line.opengl_version": "Versione di OpenGL",
   "text.betterf3.line.gpu_driver": "Driver della GPU",
   "text.betterf3.line.misc_left": "Varie sinistra",
   "text.betterf3.line.misc_right": "Varie destra",

--- a/common/src/main/resources/assets/betterf3/lang/ja_jp.json
+++ b/common/src/main/resources/assets/betterf3/lang/ja_jp.json
@@ -213,7 +213,6 @@
   "text.betterf3.line.display": "ディスプレイ",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU使用率",
-  "text.betterf3.line.opengl_version": "OpenGLのバージョン",
   "text.betterf3.line.gpu_driver": "GPUドライバー",
   "text.betterf3.line.misc_left": "その他(左側)",
   "text.betterf3.line.misc_right": "その他(右側)",

--- a/common/src/main/resources/assets/betterf3/lang/ja_jp.json
+++ b/common/src/main/resources/assets/betterf3/lang/ja_jp.json
@@ -213,6 +213,7 @@
   "text.betterf3.line.display": "ディスプレイ",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU使用率",
+  "text.betterf3.line.opengl_version": "OpenGLのバージョン",
   "text.betterf3.line.gpu_driver": "GPUドライバー",
   "text.betterf3.line.misc_left": "その他(左側)",
   "text.betterf3.line.misc_right": "その他(右側)",

--- a/common/src/main/resources/assets/betterf3/lang/jbo_en.json
+++ b/common/src/main/resources/assets/betterf3/lang/jbo_en.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.opengl_version": "OpenGL Version",
+  "text.betterf3.line.graphics_api": "Graphics API",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/jbo_en.json
+++ b/common/src/main/resources/assets/betterf3/lang/jbo_en.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.graphics_api": "Graphics API",
+  "text.betterf3.line.opengl_version": "OpenGL Version",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/ka_ge.json
+++ b/common/src/main/resources/assets/betterf3/lang/ka_ge.json
@@ -213,6 +213,7 @@
   "text.betterf3.line.display": "ეკრანი",
   "text.betterf3.line.gpu": "ვიდეობარათი",
   "text.betterf3.line.gpu_utilization": "ვიდეობარათის გამოყენება",
+  "text.betterf3.line.opengl_version": "OpenGL-ის ვერსია",
   "text.betterf3.line.gpu_driver": "ვიდეობარათის დრაივერი",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/ka_ge.json
+++ b/common/src/main/resources/assets/betterf3/lang/ka_ge.json
@@ -213,7 +213,6 @@
   "text.betterf3.line.display": "ეკრანი",
   "text.betterf3.line.gpu": "ვიდეობარათი",
   "text.betterf3.line.gpu_utilization": "ვიდეობარათის გამოყენება",
-  "text.betterf3.line.opengl_version": "OpenGL-ის ვერსია",
   "text.betterf3.line.gpu_driver": "ვიდეობარათის დრაივერი",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/kk_kz.json
+++ b/common/src/main/resources/assets/betterf3/lang/kk_kz.json
@@ -213,7 +213,6 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "ГП",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.opengl_version": "OpenGL нұсқасы",
   "text.betterf3.line.gpu_driver": "ГП драйвері",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/kk_kz.json
+++ b/common/src/main/resources/assets/betterf3/lang/kk_kz.json
@@ -213,6 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "ГП",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
+  "text.betterf3.line.opengl_version": "OpenGL нұсқасы",
   "text.betterf3.line.gpu_driver": "ГП драйвері",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/kn_in.json
+++ b/common/src/main/resources/assets/betterf3/lang/kn_in.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.opengl_version": "OpenGL Version",
+  "text.betterf3.line.graphics_api": "Graphics API",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/kn_in.json
+++ b/common/src/main/resources/assets/betterf3/lang/kn_in.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.graphics_api": "Graphics API",
+  "text.betterf3.line.opengl_version": "OpenGL Version",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/ko_kr.json
+++ b/common/src/main/resources/assets/betterf3/lang/ko_kr.json
@@ -213,6 +213,7 @@
   "text.betterf3.line.display": "디스플레이",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU 사용률",
+  "text.betterf3.line.opengl_version": "OpenGL 버전",
   "text.betterf3.line.gpu_driver": "GPU 드라이버",
   "text.betterf3.line.misc_left": "기타 왼쪽",
   "text.betterf3.line.misc_right": "기타 오른쪽",

--- a/common/src/main/resources/assets/betterf3/lang/ko_kr.json
+++ b/common/src/main/resources/assets/betterf3/lang/ko_kr.json
@@ -213,7 +213,6 @@
   "text.betterf3.line.display": "디스플레이",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU 사용률",
-  "text.betterf3.line.opengl_version": "OpenGL 버전",
   "text.betterf3.line.gpu_driver": "GPU 드라이버",
   "text.betterf3.line.misc_left": "기타 왼쪽",
   "text.betterf3.line.misc_right": "기타 오른쪽",

--- a/common/src/main/resources/assets/betterf3/lang/ku.json
+++ b/common/src/main/resources/assets/betterf3/lang/ku.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.opengl_version": "OpenGL Version",
+  "text.betterf3.line.graphics_api": "Graphics API",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/ku.json
+++ b/common/src/main/resources/assets/betterf3/lang/ku.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.graphics_api": "Graphics API",
+  "text.betterf3.line.opengl_version": "OpenGL Version",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/la_la.json
+++ b/common/src/main/resources/assets/betterf3/lang/la_la.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.opengl_version": "OpenGL Version",
+  "text.betterf3.line.graphics_api": "Graphics API",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/la_la.json
+++ b/common/src/main/resources/assets/betterf3/lang/la_la.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.graphics_api": "Graphics API",
+  "text.betterf3.line.opengl_version": "OpenGL Version",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/lb_lu.json
+++ b/common/src/main/resources/assets/betterf3/lang/lb_lu.json
@@ -213,7 +213,6 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Auslaaschtung",
-  "text.betterf3.line.opengl_version": "OpenGL Versioun",
   "text.betterf3.line.gpu_driver": "GPU Dreiwer",
   "text.betterf3.line.misc_left": "Aaner Lénks",
   "text.betterf3.line.misc_right": "Aaner Riets",

--- a/common/src/main/resources/assets/betterf3/lang/lb_lu.json
+++ b/common/src/main/resources/assets/betterf3/lang/lb_lu.json
@@ -213,6 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Auslaaschtung",
+  "text.betterf3.line.opengl_version": "OpenGL Versioun",
   "text.betterf3.line.gpu_driver": "GPU Dreiwer",
   "text.betterf3.line.misc_left": "Aaner Lénks",
   "text.betterf3.line.misc_right": "Aaner Riets",

--- a/common/src/main/resources/assets/betterf3/lang/li_li.json
+++ b/common/src/main/resources/assets/betterf3/lang/li_li.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.opengl_version": "OpenGL Version",
+  "text.betterf3.line.graphics_api": "Graphics API",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/li_li.json
+++ b/common/src/main/resources/assets/betterf3/lang/li_li.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.graphics_api": "Graphics API",
+  "text.betterf3.line.opengl_version": "OpenGL Version",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/lol_us.json
+++ b/common/src/main/resources/assets/betterf3/lang/lol_us.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.opengl_version": "OpenGL Version",
+  "text.betterf3.line.graphics_api": "Graphics API",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/lol_us.json
+++ b/common/src/main/resources/assets/betterf3/lang/lol_us.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.graphics_api": "Graphics API",
+  "text.betterf3.line.opengl_version": "OpenGL Version",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/lt_lt.json
+++ b/common/src/main/resources/assets/betterf3/lang/lt_lt.json
@@ -213,6 +213,7 @@
   "text.betterf3.line.display": "Rodymas",
   "text.betterf3.line.gpu": "Grafikos procesorius",
   "text.betterf3.line.gpu_utilization": "Grafikos procesoriaus naudojimas",
+  "text.betterf3.line.opengl_version": "OpenGL versija",
   "text.betterf3.line.gpu_driver": "Grafikos procesoriaus tvarkyklė",
   "text.betterf3.line.misc_left": "Įvairūs kairėje",
   "text.betterf3.line.misc_right": "Įvairūs dešinėje",

--- a/common/src/main/resources/assets/betterf3/lang/lt_lt.json
+++ b/common/src/main/resources/assets/betterf3/lang/lt_lt.json
@@ -213,7 +213,6 @@
   "text.betterf3.line.display": "Rodymas",
   "text.betterf3.line.gpu": "Grafikos procesorius",
   "text.betterf3.line.gpu_utilization": "Grafikos procesoriaus naudojimas",
-  "text.betterf3.line.opengl_version": "OpenGL versija",
   "text.betterf3.line.gpu_driver": "Grafikos procesoriaus tvarkyklė",
   "text.betterf3.line.misc_left": "Įvairūs kairėje",
   "text.betterf3.line.misc_right": "Įvairūs dešinėje",

--- a/common/src/main/resources/assets/betterf3/lang/lv_lv.json
+++ b/common/src/main/resources/assets/betterf3/lang/lv_lv.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.opengl_version": "OpenGL Version",
+  "text.betterf3.line.graphics_api": "Graphics API",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/lv_lv.json
+++ b/common/src/main/resources/assets/betterf3/lang/lv_lv.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.graphics_api": "Graphics API",
+  "text.betterf3.line.opengl_version": "OpenGL Version",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/mk_mk.json
+++ b/common/src/main/resources/assets/betterf3/lang/mk_mk.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.opengl_version": "OpenGL Version",
+  "text.betterf3.line.graphics_api": "Graphics API",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/mk_mk.json
+++ b/common/src/main/resources/assets/betterf3/lang/mk_mk.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.graphics_api": "Graphics API",
+  "text.betterf3.line.opengl_version": "OpenGL Version",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/mn_mn.json
+++ b/common/src/main/resources/assets/betterf3/lang/mn_mn.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.opengl_version": "OpenGL Version",
+  "text.betterf3.line.graphics_api": "Graphics API",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/mn_mn.json
+++ b/common/src/main/resources/assets/betterf3/lang/mn_mn.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.graphics_api": "Graphics API",
+  "text.betterf3.line.opengl_version": "OpenGL Version",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/ms_my.json
+++ b/common/src/main/resources/assets/betterf3/lang/ms_my.json
@@ -213,7 +213,6 @@
   "text.betterf3.line.display": "Paparan",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "Kegunaan GPU",
-  "text.betterf3.line.opengl_version": "Versi OpenGL",
   "text.betterf3.line.gpu_driver": "Pemacu GPU",
   "text.betterf3.line.misc_left": "Lain-Lain Kiri",
   "text.betterf3.line.misc_right": "Lain-Lain Kanan",

--- a/common/src/main/resources/assets/betterf3/lang/ms_my.json
+++ b/common/src/main/resources/assets/betterf3/lang/ms_my.json
@@ -213,6 +213,7 @@
   "text.betterf3.line.display": "Paparan",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "Kegunaan GPU",
+  "text.betterf3.line.opengl_version": "Versi OpenGL",
   "text.betterf3.line.gpu_driver": "Pemacu GPU",
   "text.betterf3.line.misc_left": "Lain-Lain Kiri",
   "text.betterf3.line.misc_right": "Lain-Lain Kanan",

--- a/common/src/main/resources/assets/betterf3/lang/mt_mt.json
+++ b/common/src/main/resources/assets/betterf3/lang/mt_mt.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.opengl_version": "OpenGL Version",
+  "text.betterf3.line.graphics_api": "Graphics API",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/mt_mt.json
+++ b/common/src/main/resources/assets/betterf3/lang/mt_mt.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.graphics_api": "Graphics API",
+  "text.betterf3.line.opengl_version": "OpenGL Version",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/nds_de.json
+++ b/common/src/main/resources/assets/betterf3/lang/nds_de.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.opengl_version": "OpenGL Version",
+  "text.betterf3.line.graphics_api": "Graphics API",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/nds_de.json
+++ b/common/src/main/resources/assets/betterf3/lang/nds_de.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.graphics_api": "Graphics API",
+  "text.betterf3.line.opengl_version": "OpenGL Version",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/nl_be.json
+++ b/common/src/main/resources/assets/betterf3/lang/nl_be.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.opengl_version": "OpenGL Version",
+  "text.betterf3.line.graphics_api": "Graphics API",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/nl_be.json
+++ b/common/src/main/resources/assets/betterf3/lang/nl_be.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.graphics_api": "Graphics API",
+  "text.betterf3.line.opengl_version": "OpenGL Version",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/nl_nl.json
+++ b/common/src/main/resources/assets/betterf3/lang/nl_nl.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.opengl_version": "OpenGL Version",
+  "text.betterf3.line.graphics_api": "Graphics API",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/nl_nl.json
+++ b/common/src/main/resources/assets/betterf3/lang/nl_nl.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.graphics_api": "Graphics API",
+  "text.betterf3.line.opengl_version": "OpenGL Version",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/nn_no.json
+++ b/common/src/main/resources/assets/betterf3/lang/nn_no.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.opengl_version": "OpenGL Version",
+  "text.betterf3.line.graphics_api": "Graphics API",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/nn_no.json
+++ b/common/src/main/resources/assets/betterf3/lang/nn_no.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.graphics_api": "Graphics API",
+  "text.betterf3.line.opengl_version": "OpenGL Version",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/no_no.json
+++ b/common/src/main/resources/assets/betterf3/lang/no_no.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.opengl_version": "OpenGL Version",
+  "text.betterf3.line.graphics_api": "Graphics API",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/no_no.json
+++ b/common/src/main/resources/assets/betterf3/lang/no_no.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.graphics_api": "Graphics API",
+  "text.betterf3.line.opengl_version": "OpenGL Version",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/oc_fr.json
+++ b/common/src/main/resources/assets/betterf3/lang/oc_fr.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.opengl_version": "OpenGL Version",
+  "text.betterf3.line.graphics_api": "Graphics API",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/oc_fr.json
+++ b/common/src/main/resources/assets/betterf3/lang/oc_fr.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.graphics_api": "Graphics API",
+  "text.betterf3.line.opengl_version": "OpenGL Version",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/pl_pl.json
+++ b/common/src/main/resources/assets/betterf3/lang/pl_pl.json
@@ -213,6 +213,7 @@
   "text.betterf3.line.display": "Wyświetlacz",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "Wykorzystanie GPU",
+  "text.betterf3.line.opengl_version": "Wersja OpenGL",
   "text.betterf3.line.gpu_driver": "Sterownik GPU",
   "text.betterf3.line.misc_left": "Inne (po lewej)",
   "text.betterf3.line.misc_right": "Inne (po prawej)",

--- a/common/src/main/resources/assets/betterf3/lang/pl_pl.json
+++ b/common/src/main/resources/assets/betterf3/lang/pl_pl.json
@@ -213,7 +213,6 @@
   "text.betterf3.line.display": "Wyświetlacz",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "Wykorzystanie GPU",
-  "text.betterf3.line.opengl_version": "Wersja OpenGL",
   "text.betterf3.line.gpu_driver": "Sterownik GPU",
   "text.betterf3.line.misc_left": "Inne (po lewej)",
   "text.betterf3.line.misc_right": "Inne (po prawej)",

--- a/common/src/main/resources/assets/betterf3/lang/pt_br.json
+++ b/common/src/main/resources/assets/betterf3/lang/pt_br.json
@@ -213,6 +213,7 @@
   "text.betterf3.line.display": "Monitor",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "Utilização da GPU",
+  "text.betterf3.line.opengl_version": "Versão do OpenGL",
   "text.betterf3.line.gpu_driver": "Driver da GPU",
   "text.betterf3.line.misc_left": "Extras da Esquerda",
   "text.betterf3.line.misc_right": "Extras da Direita",

--- a/common/src/main/resources/assets/betterf3/lang/pt_br.json
+++ b/common/src/main/resources/assets/betterf3/lang/pt_br.json
@@ -213,7 +213,6 @@
   "text.betterf3.line.display": "Monitor",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "Utilização da GPU",
-  "text.betterf3.line.opengl_version": "Versão do OpenGL",
   "text.betterf3.line.gpu_driver": "Driver da GPU",
   "text.betterf3.line.misc_left": "Extras da Esquerda",
   "text.betterf3.line.misc_right": "Extras da Direita",

--- a/common/src/main/resources/assets/betterf3/lang/pt_pt.json
+++ b/common/src/main/resources/assets/betterf3/lang/pt_pt.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.opengl_version": "OpenGL Version",
+  "text.betterf3.line.graphics_api": "Graphics API",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/pt_pt.json
+++ b/common/src/main/resources/assets/betterf3/lang/pt_pt.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.graphics_api": "Graphics API",
+  "text.betterf3.line.opengl_version": "OpenGL Version",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/qya_aa.json
+++ b/common/src/main/resources/assets/betterf3/lang/qya_aa.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.opengl_version": "OpenGL Version",
+  "text.betterf3.line.graphics_api": "Graphics API",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/qya_aa.json
+++ b/common/src/main/resources/assets/betterf3/lang/qya_aa.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.graphics_api": "Graphics API",
+  "text.betterf3.line.opengl_version": "OpenGL Version",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/ro_ro.json
+++ b/common/src/main/resources/assets/betterf3/lang/ro_ro.json
@@ -213,6 +213,7 @@
   "text.betterf3.line.display": "Afişare",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "Utilizare GPU",
+  "text.betterf3.line.opengl_version": "Versiunea OpenGL",
   "text.betterf3.line.gpu_driver": "Driver GPU",
   "text.betterf3.line.misc_left": "Diverse Stânga",
   "text.betterf3.line.misc_right": "Diverse Dreapta",

--- a/common/src/main/resources/assets/betterf3/lang/ro_ro.json
+++ b/common/src/main/resources/assets/betterf3/lang/ro_ro.json
@@ -213,7 +213,6 @@
   "text.betterf3.line.display": "Afişare",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "Utilizare GPU",
-  "text.betterf3.line.opengl_version": "Versiunea OpenGL",
   "text.betterf3.line.gpu_driver": "Driver GPU",
   "text.betterf3.line.misc_left": "Diverse Stânga",
   "text.betterf3.line.misc_right": "Diverse Dreapta",

--- a/common/src/main/resources/assets/betterf3/lang/ru_ru.json
+++ b/common/src/main/resources/assets/betterf3/lang/ru_ru.json
@@ -213,6 +213,7 @@
   "text.betterf3.line.display": "Окно",
   "text.betterf3.line.gpu": "ГП",
   "text.betterf3.line.gpu_utilization": "Использование ГП",
+  "text.betterf3.line.opengl_version": "Версия OpenGL",
   "text.betterf3.line.gpu_driver": "Драйвер ГП",
   "text.betterf3.line.misc_left": "\"Прочее\" слева",
   "text.betterf3.line.misc_right": "\"Прочее\" справа",

--- a/common/src/main/resources/assets/betterf3/lang/ru_ru.json
+++ b/common/src/main/resources/assets/betterf3/lang/ru_ru.json
@@ -213,7 +213,6 @@
   "text.betterf3.line.display": "Окно",
   "text.betterf3.line.gpu": "ГП",
   "text.betterf3.line.gpu_utilization": "Использование ГП",
-  "text.betterf3.line.opengl_version": "Версия OpenGL",
   "text.betterf3.line.gpu_driver": "Драйвер ГП",
   "text.betterf3.line.misc_left": "\"Прочее\" слева",
   "text.betterf3.line.misc_right": "\"Прочее\" справа",

--- a/common/src/main/resources/assets/betterf3/lang/se_no.json
+++ b/common/src/main/resources/assets/betterf3/lang/se_no.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.opengl_version": "OpenGL Version",
+  "text.betterf3.line.graphics_api": "Graphics API",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/se_no.json
+++ b/common/src/main/resources/assets/betterf3/lang/se_no.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.graphics_api": "Graphics API",
+  "text.betterf3.line.opengl_version": "OpenGL Version",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/sk_sk.json
+++ b/common/src/main/resources/assets/betterf3/lang/sk_sk.json
@@ -213,7 +213,6 @@
   "text.betterf3.line.display": "Displej",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.opengl_version": "Verzia OpenGL",
   "text.betterf3.line.gpu_driver": "GPU driver",
   "text.betterf3.line.misc_left": "Ostatné naľavo",
   "text.betterf3.line.misc_right": "Ostatné napravo",

--- a/common/src/main/resources/assets/betterf3/lang/sk_sk.json
+++ b/common/src/main/resources/assets/betterf3/lang/sk_sk.json
@@ -213,6 +213,7 @@
   "text.betterf3.line.display": "Displej",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
+  "text.betterf3.line.opengl_version": "Verzia OpenGL",
   "text.betterf3.line.gpu_driver": "GPU driver",
   "text.betterf3.line.misc_left": "Ostatné naľavo",
   "text.betterf3.line.misc_right": "Ostatné napravo",

--- a/common/src/main/resources/assets/betterf3/lang/sl_si.json
+++ b/common/src/main/resources/assets/betterf3/lang/sl_si.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.opengl_version": "OpenGL Version",
+  "text.betterf3.line.graphics_api": "Graphics API",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/sl_si.json
+++ b/common/src/main/resources/assets/betterf3/lang/sl_si.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.graphics_api": "Graphics API",
+  "text.betterf3.line.opengl_version": "OpenGL Version",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/so_so.json
+++ b/common/src/main/resources/assets/betterf3/lang/so_so.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.opengl_version": "OpenGL Version",
+  "text.betterf3.line.graphics_api": "Graphics API",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/so_so.json
+++ b/common/src/main/resources/assets/betterf3/lang/so_so.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.graphics_api": "Graphics API",
+  "text.betterf3.line.opengl_version": "OpenGL Version",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/sq_al.json
+++ b/common/src/main/resources/assets/betterf3/lang/sq_al.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.opengl_version": "OpenGL Version",
+  "text.betterf3.line.graphics_api": "Graphics API",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/sq_al.json
+++ b/common/src/main/resources/assets/betterf3/lang/sq_al.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.graphics_api": "Graphics API",
+  "text.betterf3.line.opengl_version": "OpenGL Version",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/sr_sp.json
+++ b/common/src/main/resources/assets/betterf3/lang/sr_sp.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.opengl_version": "OpenGL Version",
+  "text.betterf3.line.graphics_api": "Graphics API",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/sr_sp.json
+++ b/common/src/main/resources/assets/betterf3/lang/sr_sp.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.graphics_api": "Graphics API",
+  "text.betterf3.line.opengl_version": "OpenGL Version",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/sv_se.json
+++ b/common/src/main/resources/assets/betterf3/lang/sv_se.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.opengl_version": "OpenGL Version",
+  "text.betterf3.line.graphics_api": "Graphics API",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Övrigt vänster",
   "text.betterf3.line.misc_right": "Övrigt höger",

--- a/common/src/main/resources/assets/betterf3/lang/sv_se.json
+++ b/common/src/main/resources/assets/betterf3/lang/sv_se.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.graphics_api": "Graphics API",
+  "text.betterf3.line.opengl_version": "OpenGL Version",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Övrigt vänster",
   "text.betterf3.line.misc_right": "Övrigt höger",

--- a/common/src/main/resources/assets/betterf3/lang/ta_in.json
+++ b/common/src/main/resources/assets/betterf3/lang/ta_in.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.opengl_version": "OpenGL Version",
+  "text.betterf3.line.graphics_api": "Graphics API",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/ta_in.json
+++ b/common/src/main/resources/assets/betterf3/lang/ta_in.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.graphics_api": "Graphics API",
+  "text.betterf3.line.opengl_version": "OpenGL Version",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/th_th.json
+++ b/common/src/main/resources/assets/betterf3/lang/th_th.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.opengl_version": "OpenGL Version",
+  "text.betterf3.line.graphics_api": "Graphics API",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/th_th.json
+++ b/common/src/main/resources/assets/betterf3/lang/th_th.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.graphics_api": "Graphics API",
+  "text.betterf3.line.opengl_version": "OpenGL Version",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/tl_ph.json
+++ b/common/src/main/resources/assets/betterf3/lang/tl_ph.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.opengl_version": "OpenGL Version",
+  "text.betterf3.line.graphics_api": "Graphics API",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/tl_ph.json
+++ b/common/src/main/resources/assets/betterf3/lang/tl_ph.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.graphics_api": "Graphics API",
+  "text.betterf3.line.opengl_version": "OpenGL Version",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/tlh_aa.json
+++ b/common/src/main/resources/assets/betterf3/lang/tlh_aa.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.opengl_version": "OpenGL Version",
+  "text.betterf3.line.graphics_api": "Graphics API",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/tlh_aa.json
+++ b/common/src/main/resources/assets/betterf3/lang/tlh_aa.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.graphics_api": "Graphics API",
+  "text.betterf3.line.opengl_version": "OpenGL Version",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/tr_tr.json
+++ b/common/src/main/resources/assets/betterf3/lang/tr_tr.json
@@ -213,7 +213,6 @@
   "text.betterf3.line.display": "Ekran",
   "text.betterf3.line.gpu": "Ekran Kartı (GPU)",
   "text.betterf3.line.gpu_utilization": "Ekran Kartı Kullanımı",
-  "text.betterf3.line.opengl_version": "OpenGL Sürümü",
   "text.betterf3.line.gpu_driver": "GPU Sürücüsü",
   "text.betterf3.line.misc_left": "Çeşitli Sol",
   "text.betterf3.line.misc_right": "Çeşitli Sağ",

--- a/common/src/main/resources/assets/betterf3/lang/tr_tr.json
+++ b/common/src/main/resources/assets/betterf3/lang/tr_tr.json
@@ -213,6 +213,7 @@
   "text.betterf3.line.display": "Ekran",
   "text.betterf3.line.gpu": "Ekran Kartı (GPU)",
   "text.betterf3.line.gpu_utilization": "Ekran Kartı Kullanımı",
+  "text.betterf3.line.opengl_version": "OpenGL Sürümü",
   "text.betterf3.line.gpu_driver": "GPU Sürücüsü",
   "text.betterf3.line.misc_left": "Çeşitli Sol",
   "text.betterf3.line.misc_right": "Çeşitli Sağ",

--- a/common/src/main/resources/assets/betterf3/lang/tt_ru.json
+++ b/common/src/main/resources/assets/betterf3/lang/tt_ru.json
@@ -213,6 +213,7 @@
   "text.betterf3.line.display": "Тәрәзә",
   "text.betterf3.line.gpu": "ГП",
   "text.betterf3.line.gpu_utilization": "ГП куллану",
+  "text.betterf3.line.opengl_version": "OpenGL версиясе",
   "text.betterf3.line.gpu_driver": "ГП драйверы",
   "text.betterf3.line.misc_left": "Бүтән сулда",
   "text.betterf3.line.misc_right": "Бүтән уңда",

--- a/common/src/main/resources/assets/betterf3/lang/tt_ru.json
+++ b/common/src/main/resources/assets/betterf3/lang/tt_ru.json
@@ -213,7 +213,6 @@
   "text.betterf3.line.display": "Тәрәзә",
   "text.betterf3.line.gpu": "ГП",
   "text.betterf3.line.gpu_utilization": "ГП куллану",
-  "text.betterf3.line.opengl_version": "OpenGL версиясе",
   "text.betterf3.line.gpu_driver": "ГП драйверы",
   "text.betterf3.line.misc_left": "Бүтән сулда",
   "text.betterf3.line.misc_right": "Бүтән уңда",

--- a/common/src/main/resources/assets/betterf3/lang/uk_ua.json
+++ b/common/src/main/resources/assets/betterf3/lang/uk_ua.json
@@ -213,6 +213,7 @@
   "text.betterf3.line.display": "Дисплей",
   "text.betterf3.line.gpu": "Відеокарта",
   "text.betterf3.line.gpu_utilization": "Використання відеокарти",
+  "text.betterf3.line.opengl_version": "Версія OpenGL",
   "text.betterf3.line.gpu_driver": "Драйвер відеокарти",
   "text.betterf3.line.misc_left": "\"Інше\" зліва",
   "text.betterf3.line.misc_right": "\"Інше\" справа",

--- a/common/src/main/resources/assets/betterf3/lang/uk_ua.json
+++ b/common/src/main/resources/assets/betterf3/lang/uk_ua.json
@@ -213,7 +213,6 @@
   "text.betterf3.line.display": "Дисплей",
   "text.betterf3.line.gpu": "Відеокарта",
   "text.betterf3.line.gpu_utilization": "Використання відеокарти",
-  "text.betterf3.line.opengl_version": "Версія OpenGL",
   "text.betterf3.line.gpu_driver": "Драйвер відеокарти",
   "text.betterf3.line.misc_left": "\"Інше\" зліва",
   "text.betterf3.line.misc_right": "\"Інше\" справа",

--- a/common/src/main/resources/assets/betterf3/lang/val_es.json
+++ b/common/src/main/resources/assets/betterf3/lang/val_es.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.opengl_version": "OpenGL Version",
+  "text.betterf3.line.graphics_api": "Graphics API",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/val_es.json
+++ b/common/src/main/resources/assets/betterf3/lang/val_es.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.graphics_api": "Graphics API",
+  "text.betterf3.line.opengl_version": "OpenGL Version",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/vec_it.json
+++ b/common/src/main/resources/assets/betterf3/lang/vec_it.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.opengl_version": "OpenGL Version",
+  "text.betterf3.line.graphics_api": "Graphics API",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/vec_it.json
+++ b/common/src/main/resources/assets/betterf3/lang/vec_it.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.graphics_api": "Graphics API",
+  "text.betterf3.line.opengl_version": "OpenGL Version",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/vi_vn.json
+++ b/common/src/main/resources/assets/betterf3/lang/vi_vn.json
@@ -213,7 +213,6 @@
   "text.betterf3.line.display": "Hiển thị",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "Sử dụng GPU",
-  "text.betterf3.line.opengl_version": "Phiên bản OpenGL",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Khác bên trái",
   "text.betterf3.line.misc_right": "Khác bên phải",

--- a/common/src/main/resources/assets/betterf3/lang/vi_vn.json
+++ b/common/src/main/resources/assets/betterf3/lang/vi_vn.json
@@ -213,6 +213,7 @@
   "text.betterf3.line.display": "Hiển thị",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "Sử dụng GPU",
+  "text.betterf3.line.opengl_version": "Phiên bản OpenGL",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Khác bên trái",
   "text.betterf3.line.misc_right": "Khác bên phải",

--- a/common/src/main/resources/assets/betterf3/lang/yi_de.json
+++ b/common/src/main/resources/assets/betterf3/lang/yi_de.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.opengl_version": "OpenGL Version",
+  "text.betterf3.line.graphics_api": "Graphics API",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/yi_de.json
+++ b/common/src/main/resources/assets/betterf3/lang/yi_de.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.graphics_api": "Graphics API",
+  "text.betterf3.line.opengl_version": "OpenGL Version",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/yo_ng.json
+++ b/common/src/main/resources/assets/betterf3/lang/yo_ng.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.opengl_version": "OpenGL Version",
+  "text.betterf3.line.graphics_api": "Graphics API",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/yo_ng.json
+++ b/common/src/main/resources/assets/betterf3/lang/yo_ng.json
@@ -213,7 +213,7 @@
   "text.betterf3.line.display": "Display",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU Utilization",
-  "text.betterf3.line.graphics_api": "Graphics API",
+  "text.betterf3.line.opengl_version": "OpenGL Version",
   "text.betterf3.line.gpu_driver": "GPU Driver",
   "text.betterf3.line.misc_left": "Misc Left",
   "text.betterf3.line.misc_right": "Misc Right",

--- a/common/src/main/resources/assets/betterf3/lang/zh_cn.json
+++ b/common/src/main/resources/assets/betterf3/lang/zh_cn.json
@@ -213,7 +213,6 @@
   "text.betterf3.line.display": "显示",
   "text.betterf3.line.gpu": "显示卡",
   "text.betterf3.line.gpu_utilization": "GPU使用率",
-  "text.betterf3.line.opengl_version": "OpenGL版本",
   "text.betterf3.line.gpu_driver": "显卡驱动程序",
   "text.betterf3.line.misc_left": "其它左侧",
   "text.betterf3.line.misc_right": "其它右侧",

--- a/common/src/main/resources/assets/betterf3/lang/zh_cn.json
+++ b/common/src/main/resources/assets/betterf3/lang/zh_cn.json
@@ -213,6 +213,7 @@
   "text.betterf3.line.display": "显示",
   "text.betterf3.line.gpu": "显示卡",
   "text.betterf3.line.gpu_utilization": "GPU使用率",
+  "text.betterf3.line.opengl_version": "OpenGL版本",
   "text.betterf3.line.gpu_driver": "显卡驱动程序",
   "text.betterf3.line.misc_left": "其它左侧",
   "text.betterf3.line.misc_right": "其它右侧",

--- a/common/src/main/resources/assets/betterf3/lang/zh_hk.json
+++ b/common/src/main/resources/assets/betterf3/lang/zh_hk.json
@@ -213,7 +213,6 @@
   "text.betterf3.line.display": "顯示",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU 使用率",
-  "text.betterf3.line.opengl_version": "OpenGL 版本",
   "text.betterf3.line.gpu_driver": "GPU 驅動程式",
   "text.betterf3.line.misc_left": "左側雜項",
   "text.betterf3.line.misc_right": "右側雜項",

--- a/common/src/main/resources/assets/betterf3/lang/zh_hk.json
+++ b/common/src/main/resources/assets/betterf3/lang/zh_hk.json
@@ -213,6 +213,7 @@
   "text.betterf3.line.display": "顯示",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "GPU 使用率",
+  "text.betterf3.line.opengl_version": "OpenGL 版本",
   "text.betterf3.line.gpu_driver": "GPU 驅動程式",
   "text.betterf3.line.misc_left": "左側雜項",
   "text.betterf3.line.misc_right": "右側雜項",

--- a/common/src/main/resources/assets/betterf3/lang/zh_tw.json
+++ b/common/src/main/resources/assets/betterf3/lang/zh_tw.json
@@ -213,7 +213,6 @@
   "text.betterf3.line.display": "顯示器",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "顯示卡使用率",
-  "text.betterf3.line.opengl_version": "OpenGL 版本",
   "text.betterf3.line.gpu_driver": "顯示卡驅動程式",
   "text.betterf3.line.misc_left": "左側雜項",
   "text.betterf3.line.misc_right": "右側雜項",

--- a/common/src/main/resources/assets/betterf3/lang/zh_tw.json
+++ b/common/src/main/resources/assets/betterf3/lang/zh_tw.json
@@ -213,6 +213,7 @@
   "text.betterf3.line.display": "顯示器",
   "text.betterf3.line.gpu": "GPU",
   "text.betterf3.line.gpu_utilization": "顯示卡使用率",
+  "text.betterf3.line.opengl_version": "OpenGL 版本",
   "text.betterf3.line.gpu_driver": "顯示卡驅動程式",
   "text.betterf3.line.misc_left": "左側雜項",
   "text.betterf3.line.misc_right": "右側雜項",

--- a/common/src/main/resources/betterf3.accesswidener
+++ b/common/src/main/resources/betterf3.accesswidener
@@ -1,8 +1,8 @@
 accessWidener   v1  official
 accessible class net/minecraft/client/multiplayer/ClientChunkCache$Storage
-accessible field net/minecraft/client/renderer/LevelRenderer lastViewDistance I
-accessible field net/minecraft/client/renderer/LevelRenderer level Lnet/minecraft/client/multiplayer/ClientLevel;
+accessible field net/minecraft/client/renderer/extract/LevelExtractor lastViewDistance I
 accessible field net/minecraft/client/renderer/LevelRenderer viewArea Lnet/minecraft/client/renderer/ViewArea;
+accessible field net/minecraft/client/renderer/ViewArea sections Lnet/minecraft/client/RotatingSectionStorage;
 accessible field net/minecraft/client/gui/components/debug/DebugEntryHeightmap HEIGHTMAP_NAMES Ljava/util/Map;
 accessible field net/minecraft/client/gui/components/DebugScreenOverlay renderFpsCharts Z
 accessible field net/minecraft/client/gui/components/DebugScreenOverlay renderProfilerChart Z

--- a/docs/changelogs/19.0.0.md
+++ b/docs/changelogs/19.0.0.md
@@ -1,0 +1,8 @@
+! last_version=18.0.3
+!
+### Added
+- Full Minecraft 26.2 release support for Fabric and NeoForge.
+
+### Changed
+- Project version bumped to `19.0.0`.
+- Changed `OpenGL Version` to `Graphics API`.

--- a/docs/changelogs/19.0.0.md
+++ b/docs/changelogs/19.0.0.md
@@ -1,4 +1,4 @@
-! last_version=18.0.3
+! last_version=18.0.2
 !
 ### Added
 - Full Minecraft 26.2 release support for Fabric and NeoForge.
@@ -6,3 +6,5 @@
 ### Changed
 - Project version bumped to `19.0.0`.
 - Changed `OpenGL Version` to `Graphics API`.
+
+Huge thanks to [@ShadowCat117](https://github.com/ShadowCat117)!

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,23 +4,23 @@ org.gradle.daemon=false
 
 archives_base_name=BetterF3
 
-minecraft_version=26.1
-supported_minecraft_versions=26.1-26.1.2
-supported_minecraft_versions_list=26.1,26.1.1,26.1.2
+minecraft_version=26.2
+supported_minecraft_versions=26.2
+supported_minecraft_versions_list=26.2
 
-mod_version=18.0.2
+mod_version=19.0.0
 releaseType=release
 maven_group=me.treyruffy.betterf3
 
 platforms=fabric,neoforge
 
-fabric_loader_version=0.19.2
-fabric_api_version=0.145.1+26.1
+fabric_loader_version=0.19.3
+fabric_api_version=0.152.2+26.2
 
-cloth_version=26.1.154
-modmenu_version=18.0.0-alpha.8
+cloth_version=26.2.155
+modmenu_version=20.0.0-beta.3
 
-neoforge_version=26.1.0.19-beta
+neoforge_version=26.2.0.6-beta
 
 modrinth_id=8shC1gFX
 curseforge_id=401648

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,9 +18,9 @@ fabric_loader_version=0.19.3
 fabric_api_version=0.152.2+26.2
 
 cloth_version=26.2.155
-modmenu_version=20.0.0-beta.3
+modmenu_version=20.0.0-beta.4
 
-neoforge_version=26.2.0.6-beta
+neoforge_version=26.2.0.8-beta
 
 modrinth_id=8shC1gFX
 curseforge_id=401648

--- a/neoforge/src/main/resources/META-INF/accesstransformer.cfg
+++ b/neoforge/src/main/resources/META-INF/accesstransformer.cfg
@@ -1,8 +1,8 @@
 # Mirrors common/src/main/resources/betterf3.accesswidener for NeoForge runtime.
 public net.minecraft.client.multiplayer.ClientChunkCache$Storage
-public net.minecraft.client.renderer.LevelRenderer lastViewDistance
-public net.minecraft.client.renderer.LevelRenderer level
+public net.minecraft.client.renderer.extract.LevelExtractor lastViewDistance
 public net.minecraft.client.renderer.LevelRenderer viewArea
+public net.minecraft.client.renderer.ViewArea sections
 public net.minecraft.client.gui.components.debug.DebugEntryHeightmap HEIGHTMAP_NAMES
 public net.minecraft.client.gui.components.DebugScreenOverlay renderFpsCharts
 public net.minecraft.client.gui.components.DebugScreenOverlay renderProfilerChart


### PR DESCRIPTION
Targeting the 26.1 branch rn, but if you make a 26.2 I can change it

Fabric works with both OpenGL and Vulkan. NeoForge seems to crash when using Vulkan even without the mod so can't verify that works.

Replaced the `opengl_version` line with `graphics_api`, API version is now just part of driver info. 
Client version type was removed with no alternative from what I can tell so that was just removed.

Not sure what you'd prefer to do for all the localisation files, I replaced all the ones that were "OpenGL Version" with "Graphics API" and the others I just removed

Fabric Vulkan
<img width="1920" height="1080" alt="2026-06-21_19 47 15" src="https://github.com/user-attachments/assets/ffdfcb5f-f87c-49ec-9315-a6817eb4cbaa" />
NeoForge OpenGL
<img width="1920" height="1080" alt="2026-06-21_19 44 54" src="https://github.com/user-attachments/assets/f69a4a46-3a35-428e-8bad-5b5c35a37f09" />
