### PR TITLE
fix: BaseModule constructor visibility regression from 94144b2

### DIFF
--- a/common/src/main/java/me/cominixo/betterf3/modules/BaseModule.java
+++ b/common/src/main/java/me/cominixo/betterf3/modules/BaseModule.java
@@ -102,7 +102,7 @@ public abstract class BaseModule implements Comparable<BaseModule> {
     /**
      * Instantiates a new module.
      */
-    BaseModule() {
+    public BaseModule() {
         // Do nothing
     }
 
@@ -111,7 +111,7 @@ public abstract class BaseModule implements Comparable<BaseModule> {
      *
      * @param invisible sets invisibility
      */
-    BaseModule(final boolean invisible) {
+    public BaseModule(final boolean invisible) {
         if (!invisible) {
             allModules.add(this);
         }


### PR DESCRIPTION
BaseModule's constructors lost `public` in 94144b2, silently breaking that documented extension point [CreateModule.md](https://github.com/TreyRuffy/BetterF3/blob/781d6125b497201fca69fc7c7a41c535aeaf815b/docs/developers/CreateModule.md) for any third-party module outside the `me.cominixo.betterf3.modules` package.